### PR TITLE
update mysql version

### DIFF
--- a/q4m_mysql56/setup.sh
+++ b/q4m_mysql56/setup.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-MYVER=5.6.20
+MYVER=5.6.21
 Q4MVER=0.9.14
 
 CDIR=$(cd $(dirname $0) && pwd)


### PR DESCRIPTION
Mysql-5.6.20 doesn't already exist at http://ftp.jaist.ac.jp/pub/mysql/Downloads/MySQL-5.6/ .
So `wget http://ftp.jaist.ac.jp/pub/mysql/Downloads/MySQL-5.6/mysql-$MYVER.tar.gz` fails.
I updated `MYVER` to 5.6.21.
